### PR TITLE
Replace shorthash with sha1

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
     "flat-cache": "^2.0.1",
     "node-fetch": "^2.6.0",
     "p-queue": "^6.3.0",
-    "short-hash": "^1.0.0"
+    "sha1": "^1.1.1"
   },
   "ava": {
     "failFast": true,

--- a/src/RemoteAssetCache.js
+++ b/src/RemoteAssetCache.js
@@ -2,14 +2,14 @@ const fs = require("fs");
 const fsp = fs.promises; // Node 10+
 const path = require("path");
 const fetch = require("node-fetch");
-const shorthash = require("short-hash");
+const sha1 = require("sha1");
 const flatCache = require("flat-cache");
 const AssetCache = require("./AssetCache");
 const debug = require("debug")("EleventyCacheAssets");
 
 class RemoteAssetCache extends AssetCache {
 	constructor(url, cacheDirectory) {
-		super(shorthash(url), cacheDirectory);
+		super(sha1(url), cacheDirectory);
 		this.url = url;
 	}
 

--- a/test/RemoteAssetCacheTest.js
+++ b/test/RemoteAssetCacheTest.js
@@ -1,7 +1,7 @@
 const test = require("ava");
 const path = require("path");
 const fs = require("fs");
-const shorthash = require("short-hash");
+const sha1 = require("sha1");
 const RemoteAssetCache = require("../src/RemoteAssetCache");
 
 let fsp = fs.promises;
@@ -25,18 +25,18 @@ test("getDurationMs", t => {
 
 test("Local hash file names", async t => {
 	let pngUrl = "https://www.zachleat.com/img/avatar-2017-big.png";
-	t.is((new RemoteAssetCache(pngUrl)).cachePath, path.resolve(".", `.cache/eleventy-cache-assets-${shorthash(pngUrl)}`));
+	t.is((new RemoteAssetCache(pngUrl)).cachePath, path.resolve(".", `.cache/eleventy-cache-assets-${sha1(pngUrl)}`));
 
 	let fontUrl = "https://www.zachleat.com/font.woff";
-	t.is((new RemoteAssetCache(fontUrl)).cachePath, path.resolve(".", `.cache/eleventy-cache-assets-${shorthash(fontUrl)}`));
+	t.is((new RemoteAssetCache(fontUrl)).cachePath, path.resolve(".", `.cache/eleventy-cache-assets-${sha1(fontUrl)}`));
 
 	let fontUrl2 = "https://www.zachleat.com/font.woff2";
-	t.is((new RemoteAssetCache(fontUrl2)).cachePath, path.resolve(".", `.cache/eleventy-cache-assets-${shorthash(fontUrl2)}`));
+	t.is((new RemoteAssetCache(fontUrl2)).cachePath, path.resolve(".", `.cache/eleventy-cache-assets-${sha1(fontUrl2)}`));
 });
 
 test("Local hash without file extension in URL", async t => {
 	let noExt = "https://twitter.com/zachleat/profile_image?size=bigger";
-	t.is((new RemoteAssetCache(noExt)).cachePath, path.resolve(".", `.cache/eleventy-cache-assets-${shorthash(noExt)}`));
+	t.is((new RemoteAssetCache(noExt)).cachePath, path.resolve(".", `.cache/eleventy-cache-assets-${sha1(noExt)}`));
 });
 
 test("Unique hashes for URLs", async t => {

--- a/test/RemoteAssetCacheTest.js
+++ b/test/RemoteAssetCacheTest.js
@@ -39,6 +39,14 @@ test("Local hash without file extension in URL", async t => {
 	t.is((new RemoteAssetCache(noExt)).cachePath, path.resolve(".", `.cache/eleventy-cache-assets-${shorthash(noExt)}`));
 });
 
+test("Unique hashes for URLs", async t => {
+  let apiURL1 = 'https://api.zooniverse.org/projects/illustratedlife/talk/subjects/ASC0000qu3';
+  let apiURL2 = 'https://api.zooniverse.org/projects/illustratedlife/talk/subjects/ASC0000q71';
+  let cachePath1 = new RemoteAssetCache(apiURL1).cachePath;
+  let cachePath2 = new RemoteAssetCache(apiURL2).cachePath;
+  t.not(cachePath1, cachePath2);
+});
+
 test("Fetching!", async t => {
 	let pngUrl = "https://www.zachleat.com/img/avatar-2017-big.png";
 	let ac = new RemoteAssetCache(pngUrl);


### PR DESCRIPTION
Adds a test for two URLs that are known to generate the same cache path with `shorthash`.

Replaces `shorthash` with `sha1` to generate unique hashes for URLs.

Closes #7.