### PR TITLE
feat(#23): Pass in a custom fetching function rather than a URL

### DIFF
--- a/eleventy-fetch.js
+++ b/eleventy-fetch.js
@@ -34,9 +34,17 @@ function isFullUrl(url) {
 	}
 }
 
+function isAwaitable(maybeAwaitable) {
+	return (typeof maybeAwaitable === "object" && typeof maybeAwaitable.then === "function") || (maybeAwaitable.constructor.name === "AsyncFunction");
+}
+
 async function save(source, options) {
-	if(!isFullUrl(source)) {
+	if(!(isFullUrl(source) || isAwaitable(source))) {
 		return Promise.reject(new Error("Caching an already local asset is not yet supported."));
+	}
+
+	if (isAwaitable(source) && !options.formatUrlForDisplay) {
+		return Promise.reject(new Error("formatUrlForDisplay must be implemented, as a Promise has been provided."));
 	}
 
 	let asset = new RemoteAssetCache(source, options.directory, options);

--- a/src/AssetCache.js
+++ b/src/AssetCache.js
@@ -7,8 +7,14 @@ const { createHash } = require("crypto");
 const debug = require("debug")("EleventyCacheAssets");
 
 class AssetCache {
-	constructor(uniqueKey, cacheDirectory, options = {}) {
-		this.uniqueKey = uniqueKey;
+	constructor(url, cacheDirectory, options = {}) {
+		let uniqueKey;
+		if ((typeof url === "object" && typeof url.then === "function") || (typeof url === "function" && url.constructor.name === "AsyncFunction")) {
+			uniqueKey = options.formatUrlForDisplay();
+		} else {
+			uniqueKey = url;
+		}
+
 		this.hash = AssetCache.getHash(uniqueKey, options.hashLength);
 		this.cacheDirectory = cacheDirectory || ".cache";
 		this.defaultDuration = "1d";
@@ -24,6 +30,7 @@ class AssetCache {
 	}
 
 	// Defult hashLength also set in global options, duplicated here for tests
+	// Default hashLength also set in global options, duplicated here for tests
 	static getHash(url, hashLength = 30) {
 		let hash = createHash("sha256");
 		hash.update(url);

--- a/test/AssetCacheTest.js
+++ b/test/AssetCacheTest.js
@@ -60,3 +60,22 @@ test("Cache path should handle slashes without creating directories, issue #14",
 
   t.is(cachePath, "/tmp/.cache/eleventy-fetch-135797dbf5ab1187e5003c49162602");
 });
+
+test("Uses formatUrlForDisplay when caching a promise", async t => {
+  let promise = Promise.resolve();
+  let displayUrl = 'mock-display-url'
+  let asset = new AssetCache(promise, ".customcache", { 
+    formatUrlForDisplay() {
+      return displayUrl;
+    }
+  });
+  let cachePath = normalizePath(asset.cachePath);
+  let jsonCachePath = normalizePath(asset.getCachedContentsPath("json"));
+
+  await asset.save({name: "Sophia Smith" }, "json");
+
+  t.truthy(fs.existsSync(jsonCachePath));
+
+  fs.unlinkSync(cachePath);
+  fs.unlinkSync(jsonCachePath);
+});


### PR DESCRIPTION
I added support for both async functions and promises as the first argument, rather than a url. You can find an example usage [here](https://github.com/doug-wade/i-want-to-be-a-fan/pull/1/commits/9421a2c7be928b0461bf325373858eef3098dbf8#diff-c306e0a99961a16f5c5c83996caa0958b94006d97f97475049ea3a08036bb5b0R40).

Addresses #23 