### PR TITLE
Cache request verbs separately

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,7 @@ npm run test
 ```
 
 - We use the [ava JavaScript test runner](https://github.com/avajs/ava) ([Assertions documentation](https://github.com/avajs/ava/blob/master/docs/03-assertions.md))
+- Running tests requires Node 14.18+
 - ℹ️ To keep tests fast, thou shalt try to avoid writing files in tests.
 
 

--- a/src/RemoteAssetCache.js
+++ b/src/RemoteAssetCache.js
@@ -11,7 +11,11 @@ class RemoteAssetCache extends AssetCache {
 		if(options.removeUrlQueryParams) {
 			cleanUrl = RemoteAssetCache.cleanUrl(cleanUrl);
 		}
-		super(cleanUrl, cacheDirectory, options);
+		let cacheKey = cleanUrl;
+		if(options.fetchOptions && options.fetchOptions.method && options.fetchOptions.method !== "GET") {
+			cacheKey = options.fetchOptions.method + cacheKey;
+		}
+		super(cacheKey, cacheDirectory, options);
 
 		this.url = url;
 		this.options = options;

--- a/src/RemoteAssetCache.js
+++ b/src/RemoteAssetCache.js
@@ -11,10 +11,16 @@ class RemoteAssetCache extends AssetCache {
 		if(options.removeUrlQueryParams) {
 			cleanUrl = RemoteAssetCache.cleanUrl(cleanUrl);
 		}
-		let cacheKey = cleanUrl;
-		if(options.fetchOptions && options.fetchOptions.method && options.fetchOptions.method !== "GET") {
-			cacheKey = options.fetchOptions.method + cacheKey;
+		let cacheKey = [cleanUrl];
+		if(options.fetchOptions) {
+			if(options.fetchOptions.method && options.fetchOptions.method !== "GET") {
+				cacheKey.push(options.fetchOptions.method);
+			}
+			if(options.fetchOptions.body) {
+				cacheKey.push(options.fetchOptions.body);
+			}
 		}
+		cacheKey = cacheKey.length > 1 ? JSON.stringify(cacheKey) : cleanUrl;
 		super(cacheKey, cacheDirectory, options);
 
 		this.url = url;

--- a/test/RemoteAssetCacheTest.js
+++ b/test/RemoteAssetCacheTest.js
@@ -75,6 +75,17 @@ test("Unique hashes for different HTTP methods", async t => {
 	t.not(cachePath1, cachePath2);
 });
 
+test("Unique hashes for different HTTP bodies", async t => {
+	let sameURL = 'https://example.com/';
+	let cachePath1 = new RemoteAssetCache(sameURL, ".cache", {
+		fetchOptions: { body: "123" }
+	}).cachePath;
+	let cachePath2 = new RemoteAssetCache(sameURL, ".cache", {
+		fetchOptions: { body: "456" }
+	}).cachePath;
+	t.not(cachePath1, cachePath2);
+});
+
 test("Fetching!", async t => {
 	let pngUrl = "https://www.zachleat.com/img/avatar-2017-big.png";
 	let ac = new RemoteAssetCache(pngUrl);

--- a/test/RemoteAssetCacheTest.js
+++ b/test/RemoteAssetCacheTest.js
@@ -53,6 +53,28 @@ test("Unique hashes for URLs", async t => {
   t.not(cachePath1, cachePath2);
 });
 
+test("Same hashes for implicit and explicit HTTP GET", async t => {
+	let sameURL = 'https://example.com/';
+	let cachePath1 = new RemoteAssetCache(sameURL, ".cache", {
+		fetchOptions: { method: "GET" }
+	}).cachePath;
+	let cachePath2 = new RemoteAssetCache(sameURL, ".cache", {
+		fetchOptions: {  }
+	}).cachePath;
+	t.is(cachePath1, cachePath2);
+});
+
+test("Unique hashes for different HTTP methods", async t => {
+	let sameURL = 'https://example.com/';
+	let cachePath1 = new RemoteAssetCache(sameURL, ".cache", {
+		fetchOptions: { method: "POST" }
+	}).cachePath;
+	let cachePath2 = new RemoteAssetCache(sameURL, ".cache", {
+		fetchOptions: { method: "DELETE" }
+	}).cachePath;
+	t.not(cachePath1, cachePath2);
+});
+
 test("Fetching!", async t => {
 	let pngUrl = "https://www.zachleat.com/img/avatar-2017-big.png";
 	let ac = new RemoteAssetCache(pngUrl);


### PR DESCRIPTION
Fixes #20.

See the tests for cases that are covered. In short:

1. Different HTTP methods (GET, POST, …) to the same URL are now cached independently.
2. Requests with different bodies are now cached independently.

This keeps backwards compatibility with the normal GET case so existing caches should continue to work for those.

There is more that could have been added. Such as independent caches based on request headers. But I think the use-case for those is getting way more fringe. But the code should make it easy for anyone to introduce such a patch themselves.