### PR TITLE
Drop node-fetch and bump engines.node to >= 18

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,7 +8,7 @@ jobs:
     strategy:
       matrix:
         os: ["ubuntu-latest", "macos-latest", "windows-latest"]
-        node: ["14", "16", "18"]
+        node: ["18", "20"]
     name: Node.js ${{ matrix.node }} on ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v3

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 # eleventy-fetch
 
-_Requires Node 14+_
+_Requires Node 18+_
 
 Formerly known as [`@11ty/eleventy-cache-assets`](https://www.npmjs.com/package/@11ty/eleventy-cache-assets).
 

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "eleventy-fetch.js"
   ],
   "engines": {
-    "node": ">=14"
+    "node": ">=18"
   },
   "funding": {
     "type": "opencollective",
@@ -45,7 +45,6 @@
   "dependencies": {
     "debug": "^4.3.4",
     "flat-cache": "^3.0.4",
-    "node-fetch": "^2.6.7",
     "p-queue": "^6.6.2"
   },
   "ava": {

--- a/src/RemoteAssetCache.js
+++ b/src/RemoteAssetCache.js
@@ -1,7 +1,6 @@
 const fs = require("fs");
 const fsp = fs.promises; // Node 10+
 
-const fetch = require("node-fetch");
 const AssetCache = require("./AssetCache");
 const debug = require("debug")("EleventyCacheAssets");
 
@@ -55,7 +54,7 @@ class RemoteAssetCache extends AssetCache {
 		} else if(type === "text") {
 			return response.text();
 		}
-		return response.buffer();
+		return Buffer.from(await response.arrayBuffer());
 	}
 
 	async fetch(optionsOverride = {}) {


### PR DESCRIPTION
[11ty itself is now requiring a minimum of Node 18](https://github.com/11ty/eleventy/blob/main/package.json#L15), and upgrading here as well unlocks the native `fetch` Web API (https://nodejs.org/en/blog/announcements/v18-release-announce#fetch-experimental) which means we can drop `node-fetch`.