### PR TITLE
Update debug module name from EleventyCacheAssets to EleventyFetch

### DIFF
--- a/eleventy-fetch.js
+++ b/eleventy-fetch.js
@@ -1,5 +1,5 @@
 const {default: PQueue} = require("p-queue");
-const debug = require("debug")("EleventyCacheAssets");
+const debug = require("debug")("EleventyFetch");
 
 const RemoteAssetCache = require("./src/RemoteAssetCache");
 const AssetCache = require("./src/AssetCache");


### PR DESCRIPTION
Looks like this didn't get updated when the package was renamed.