### PR TITLE
Adds Typings

### DIFF
--- a/eleventy-fetch.d.ts
+++ b/eleventy-fetch.d.ts
@@ -1,0 +1,26 @@
+/// <reference types="node" />
+import { Buffer } from 'buffer';
+
+export type FetchType =
+    | "json"
+    | "buffer"
+    | "text";
+
+export type EleventyFetchOptions<TType extends FetchType = "buffer"> = {
+    type?: TType;
+    directory?: string;
+    concurrency?: number;
+    fetchOptions?: RequestInit;
+    dryRun?: boolean;
+    removeUrlQueryParams?: boolean;
+    verbose?: boolean;
+    hashLength?: number;
+    duration?: string;
+    formatUrlForDisplay?: (url: string) => string;
+}
+
+export function EleventyFetch(url: string, options?: EleventyFetchOptions<"buffer">): Buffer;
+export function EleventyFetch<T>(url: string, options: EleventyFetchOptions<"json">): T;
+export function EleventyFetch(url: string, options: EleventyFetchOptions<"text">): string;
+
+export default EleventyFetch;

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
 		"url": "git+https://github.com/11ty/eleventy-fetch.git"
 	},
 	"main": "eleventy-fetch.js",
+	"types": "eleventy-fetch.d.ts",
 	"scripts": {
 		"test": "ava",
 		"sample": "node sample",
@@ -41,6 +42,7 @@
 	},
 	"homepage": "https://github.com/11ty/eleventy-fetch#readme",
 	"devDependencies": {
+		"@types/node": "^20.14.6",
 		"ava": "^5.2.0",
 		"prettier": "^3.2.5"
 	},


### PR DESCRIPTION
Resolves #43.

I tested with the following permutations:

```ts
import EleventyFetch from "@11ty/eleventy-fetch";

// Buffer
const a = await EleventyFetch("", {

});

// unknown
const b = await EleventyFetch("", {
    type: "json"
});

// string
const c = await EleventyFetch("", {
    type: "text"
});

// any
const d = await EleventyFetch<any>("", {
    type: "json"
});

// type
const e = await EleventyFetch<{ test: string }>("", {
    type: "json"
});

// Failure
const f = await EleventyFetch<any>("", {
    type: "text"
});

// Failure
const g = await EleventyFetch<string>("", {
    type: "text"
});

// Buffer
const h = await EleventyFetch("");
```

This pr also exposes the types `EleventyFetchOptions` and `FetchType`. The default generic `FetchType = "buffer"` is a little wonky, but I couldn't find another way to represent default options.