### PR TITLE
Upgrade dependencies to get rid of deprecation warnings

### DIFF
--- a/package.json
+++ b/package.json
@@ -54,8 +54,11 @@
 		"files": [
 			"./test/*.js"
 		],
-		"ignoredByWatcher": [
-			"**/.cache/**"
-		]
+		"watchMode": {
+			"ignoreChanges": [
+				"**/.cache/**",
+				"**/.customcache/**"
+			]
+		}
 	}
 }

--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
 	"dependencies": {
 		"debug": "^4.3.5",
 		"flat-cache": "^5.0.0",
-		"p-queue": "^8.0.1"
+		"p-queue": "6.6.2"
 	},
 	"ava": {
 		"failFast": false,

--- a/package.json
+++ b/package.json
@@ -41,13 +41,13 @@
 	},
 	"homepage": "https://github.com/11ty/eleventy-fetch#readme",
 	"devDependencies": {
-		"ava": "^5.2.0",
-		"prettier": "^3.2.5"
+		"ava": "^6.1.3",
+		"prettier": "^3.3.3"
 	},
 	"dependencies": {
-		"debug": "^4.3.4",
-		"flat-cache": "^3.0.4",
-		"p-queue": "^6.6.2"
+		"debug": "^4.3.5",
+		"flat-cache": "^5.0.0",
+		"p-queue": "^8.0.1"
 	},
 	"ava": {
 		"failFast": false,

--- a/src/AssetCache.js
+++ b/src/AssetCache.js
@@ -33,8 +33,8 @@ class AssetCache {
 		}
 
 		for (let k of key) {
-			k = ""+k;
-			if(k) {
+			k = "" + k;
+			if (k) {
 				hash.update(k);
 			} else {
 				throw new Error(`Not able to convert asset key (${k}) to string.`);

--- a/test/RemoteAssetCacheTest.js
+++ b/test/RemoteAssetCacheTest.js
@@ -144,14 +144,10 @@ test("Fetching pass non-stringable", async (t) => {
 	try {
 		await ac.fetch();
 	} catch (e) {
-		t.is(
-			e.message,
-			"Failed to parse URL from [object Object]"
-		);
+		t.is(e.message, "Failed to parse URL from [object Object]");
 		t.truthy(e.cause);
 	}
 });
-
 
 test("formatUrlForDisplay (manual query param removal)", async (t) => {
 	let finalUrl = "https://example.com/207115/photos/243-0-1.jpg";


### PR DESCRIPTION
Running `npm install --omit "dev"` before this PR:

```
npm WARN deprecated inflight@1.0.6: This module is not supported, and leaks memory. Do not use it. Check out lru-cache if you want a good and tested way to coalesce async requests by a key value, which is much more comprehensive and powerful.
npm WARN deprecated rimraf@3.0.2: Rimraf versions prior to v4 are no longer supported
npm WARN deprecated glob@7.2.3: Glob versions prior to v9 are no longer supported

added 22 packages, and audited 23 packages in 7s
```

And after:
```
added 10 packages, and audited 11 packages in 7s
```

Warnings were caused by dependencies from flat-cache. Previously eleventy-fetch was blocked from updating because of the supported Node.js version, but now that 18+ is required we align with flat-cache again.

Overall these upgrades half our number of dependencies and get rid of all the warnings! 🥳 

Additional notes:

1. p-queue has gone ESM-only. For now, eleventy-fetch has not made that step. This PR pins the p-queue dependency to the exact last non-ESM version.
   
2. AVA is upgraded to the latest version of the test runner. This will result in an Unsupported engine warning on Node.js below version 18.18. However I was able to run the eleventy-fetch tests with AVA on Node.js v18.0.0 no problem, and I think it is worth the warning (for developers only) to be able to keep dependencies in check.