### PR TITLE
Fix outdated asset key reference for custom asset filename

### DIFF
--- a/src/AssetCache.js
+++ b/src/AssetCache.js
@@ -27,7 +27,7 @@ class AssetCache {
 
 		// Compute the filename only once
 		if (typeof this.options.filenameFormat === "function") {
-			this.#customFilename = this.options.filenameFormat(this.uniqueKey, this.hash);
+			this.#customFilename = this.options.filenameFormat(uniqueKey, this.hash);
 
 			if (typeof this.#customFilename !== "string") {
 				throw new Error(`The provided cacheFilename callback function did not return a string.`);


### PR DESCRIPTION
Tracking the change of `this.uniqueKey` to `uniqueKey` (issue noticed in `5.0.0-beta.2`)