### PR TITLE
Read cached files as text unless type is "buffer"

### DIFF
--- a/src/FileCache.js
+++ b/src/FileCache.js
@@ -188,7 +188,7 @@ class FileCache {
 		// have to read the entire contents via JSON.parse (or otherwise) to check the cache validity.
 		this.#counts.read++;
 		let type = metadata?.type || this.getType();
-		let data = fs.readFileSync(this.contentsPath);
+		let data = fs.readFileSync(this.contentsPath, type !== "buffer" ? "utf8" : null);
 		if (type === "json" || type === "parsed-xml") {
 			data = JSON.parse(data);
 		}


### PR DESCRIPTION
This PR resolves https://github.com/11ty/eleventy-fetch/issues/90.

Previously, the cached file was read as text by default, unless `type` was explicitly set to `"buffer"`. This was changed in https://github.com/11ty/eleventy-fetch/commit/442070db970b2931ada3fc80ca3e399b39a129d8.

JSON and parsed XML fetches flew under the radar here only because `JSON.parse()` converts its argument to a string implicily, which in the case of a buffer, happens to result in the desired behavior.
